### PR TITLE
Unit clarification

### DIFF
--- a/src/keplerian/constructor.jl
+++ b/src/keplerian/constructor.jl
@@ -3,6 +3,13 @@
 
 Keplerian orbit parameterized by the basic observables of a transiting 2-body system.
 
+The following units are used by default:
+    * d: Days
+    * R⊙: Solar radius
+    * M⊙: Solar mass
+    * M⊙/R⊙³: Solar density
+    * rad: Radians 
+
 # Parameters
 * `period`/`P` -- The orbital period of the planet [d].
 * `t0`/`t_0` -- The midpoint time of the reference transit [d].


### PR DESCRIPTION
Based on discussion here:

https://julialang.zulipchat.com/#narrow/stream/274208-helpdesk-.28published.29/topic/rho.20in.20Orbits.2Ejl/near/328825933

Attempted to make distinction between `u"d"` and `u"°"` more clear. Also included other default unit definitions